### PR TITLE
Allow multiple Mantis backends with prefix

### DIFF
--- a/ExternalTask/MantisTask.php
+++ b/ExternalTask/MantisTask.php
@@ -32,11 +32,13 @@ class MantisTask implements ExternalTaskInterface
 
     public function getFormValues()
     {
-        $title = sprintf('MT %d %s [%s]', $this->issue->id, $this->issue->summary, $this->issue->project->name);
+        $t_id = ( $this->issue->flavor ? $this->issue->flavor . '-' : '') . sprintf( 'MT%d', $this->issue->id );
+        $title = $t_id . sprintf(' %s [%s]', 
+            $this->issue->summary, $this->issue->project->name);
         return array(
             'title' => $title,
             'description' => $this->issue->description,
-            'reference' => $this->issue->id,
+            'reference' => $t_id,
         );
     }
 }

--- a/ExternalTask/MantisTaskProvider.php
+++ b/ExternalTask/MantisTaskProvider.php
@@ -63,44 +63,107 @@ class MantisTaskProvider extends Base implements ExternalTaskProviderInterface
 
     public function buildTaskUri(array $formValues)
     {
-        return $this->getBaseUrl() . '/view.php?id=' . $formValues['id'];
+        $t_id = $this->splitID( $formValues['id'] );
+        return $this->getBaseUrl( $t_id[0] ) . '/view.php?id=' . $t_id[1];
     }
 
-    protected function getSoapClient()
+    protected function getSoapClient(string $p_id = '')
     {
         if (!isset($this->soapClient)) {
-            $this->soapClient = new SoapClient($this->getWdslUri());
+            $this->soapClient = array();
+        }
+        $t_flavor = $this->idFlavor( $p_id );
+        // error_log( 'getSoapClient id=' . $p_id . ' flavor=' . $t_flavor );
+        if( !array_key_exists( $t_flavor, $this->soapClient ) ) {
+            $this->soapClient[$t_flavor] = new SoapClient($this->getWsdlUri( $t_flavor ),
+                array(
+                    'trace' => true,
+                ));
         }
 
-        return $this->soapClient;
+        return $this->soapClient[$t_flavor];
     }
 
-    protected function getWdslUri()
+    protected function getWsdlUri(string $p_id = ''): string
     {
-        return $this->getBaseUrl() . '/api/soap/mantisconnect.php?wsdl';
+        return $this->getBaseUrl( $p_id ) . '/api/soap/mantisconnect.php?wsdl';
     }
 
-    protected function getBaseUrl()
+    protected function getBaseUrl(string $p_id = ''): string
     {
-        return $this->configModel->get('mantis_url');
+        $i = strpos( $p_id, '/view.php?id=' );
+        if( $i > 0 ) {
+            return substr( $p_id, 0, $i );
+        }
+        $t_urls = $this->getURLs();
+        $t_flavor = $this->idFlavor( $p_id );
+        if( array_key_exists( $t_flavor, $t_urls ) ) {
+            return $t_urls[$t_flavor];
+        }
+        return $t_urls[''];
     }
 
-    protected function getMantisIssue($uri)
+    private function getURLs(): array {
+        $t_urls = $this->configModel->get('mantis_url');
+        if( str_starts_with( $t_urls, '{' ) && str_ends_with( $t_urls, '}' ) ) {
+            return json_decode( $t_urls, true );
+        }
+        return array( '' => $t_urls );
+    }
+
+    protected function getMantisIssue(string $uri)
     {
         $matches = array();
-        if (preg_match('/id=(\d+)$/', $uri, $matches)) {
+        if (preg_match('/id=(?:[A-Z]-?(?:MT)?)?(\d+)$/', $uri, $matches)) {
             $id = $matches[1];
+            $t_flavor = $this->idFlavor( $uri );
             try {
-                $issue = $this->getSoapClient()->__soapCall('mc_issue_get', array(
+                $issue = $this->getSoapClient( $t_flavor )->__soapCall('mc_issue_get', array(
                     'username' => $this->configModel->get('mantis_username'),
                     'password' => $this->configModel->get('mantis_password'),
                     'issue_id' => $id,
                 ));
+                $issue->flavor = $t_flavor;
 
                 return $issue;
             } catch (\Exception $e) {
                 $this->logger->error('SOAP request failed : ' . $e->getMessage());
+                error_log('SOAP request failed: uri=' . var_export( $uri, TRUE ) . ' ERROR:' . $e->getMessage() . ' REQUEST: ' . $this->getSoapClient()->__getLastRequest() . ' RESPONSE: ' . $this->getSoapClient()->__getLastResponseHeaders());
             }
         }
     }
+
+    private function idFlavor( string $p_id ): string {
+        $i = strpos( $p_id, '/view.php?id=' );
+        if( $i ) {  // URI
+            $t_url = substr( $p_id, 0, $i );
+            foreach( $this->getURLs() as $t_key => $t_value ) {
+                if( $t_key != '' && $t_url == $t_value ) {
+                    return $t_key;
+                }
+            }
+            return '';
+        }
+        
+        $t_flavor = substr( $p_id, 0, 1);
+        if( ctype_alpha( $t_flavor ) ) {
+            if( ctype_upper( $t_flavor ) ) {
+                return $t_flavor;
+            }
+            return strtoupper( $t_flavor );
+        }    
+        return '';
+    }
+    
+    private function splitID(string|array $p_id): array {
+        if( is_array( $p_id) ) { 
+            return $p_id;
+        }
+        $matches = array();
+        if (preg_match('/^(?:([A-Za-z])-?(?:MT)?)?(\d+)$/', $p_id, $matches)) {
+            return array( strtoupper( $matches[1] ), $matches[2] );
+        }
+        return array( '', $p_id );
+    }
+
 }


### PR DESCRIPTION
If the Mantis url is a json object of prefix-url pairs like 

    {"prefix1":"url1", "prefix2":"url2", "": "default-url"}

Then the prefix is used to direct the communication to the specific Mantis instance.

If the Mantis URL is a regulare URL, then the original logic is used.

(I have separate Mantis instances per client, that's why this is useful for me).